### PR TITLE
Tune various bootstrap scripts

### DIFF
--- a/ibuildings/qa-pack/1.0/tools/phpcpd
+++ b/ibuildings/qa-pack/1.0/tools/phpcpd
@@ -5,4 +5,4 @@ cd $(dirname $0)/../../
 # https://github.com/sebastianbergmann/phpcpd
 ./vendor/bin/phpcpd \
     --names=*.php \
-    src $1
+    src tests $1

--- a/ibuildings/qa-pack/1.0/tools/phpcs.xml
+++ b/ibuildings/qa-pack/1.0/tools/phpcs.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
 <ruleset xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:noNamespaceSchemaLocation="vendor/squizlabs/php_codesniffer/phpcs.xsd">
+         xsi:noNamespaceSchemaLocation="../../vendor/squizlabs/php_codesniffer/phpcs.xsd">
 
     <arg name="basepath" value="../../"/>
     <arg name="cache" value="../../var/qa/phpcs.cache"/>
@@ -16,8 +16,8 @@
     <rule ref="Doctrine"/>
 
     <!-- Directories to be checked -->
-    <file>../../src</file>
-    <file>../../tests</file>
+    <file>../../src/</file>
+    <file>../../tests/</file>
 
     <!-- function foo(): int -->
     <rule ref="SlevomatCodingStandard.TypeHints.ReturnTypeHintSpacing">

--- a/ibuildings/qa-pack/1.0/tools/phpmd
+++ b/ibuildings/qa-pack/1.0/tools/phpmd
@@ -5,4 +5,4 @@ cd $(dirname $0)/../../
 # https://phpmd.org/documentation/index.html
 # Arguments can't be specified in phpmd.xml
 # Format: phpmd [filename|directory] [report format] [ruleset file]
-./vendor/bin/phpmd src,tests ansi tools/qa/phpmd.xml $1
+./vendor/bin/phpmd ${1:-src,tests} ansi tools/qa/phpmd.xml

--- a/ibuildings/qa-pack/1.0/tools/phpstan
+++ b/ibuildings/qa-pack/1.0/tools/phpstan
@@ -2,4 +2,6 @@
 
 cd $(dirname $0)/../../
 
-./vendor/bin/phpstan analyse -c tools/qa/phpstan.neon
+[ -f ./var/cache/dev/srcDevDebugProjectContainer.xml ] || ./bin/console cache:warmup
+
+./vendor/bin/phpstan analyse -c tools/qa/phpstan.neon $1

--- a/ibuildings/qa-pack/1.0/tools/phpstan.neon
+++ b/ibuildings/qa-pack/1.0/tools/phpstan.neon
@@ -1,10 +1,12 @@
 includes:
     - ../../vendor/phpstan/phpstan-symfony/extension.neon
     - ../../vendor/phpstan/phpstan-symfony/rules.neon
+    - ../../vendor/phpstan/phpstan-strict-rules/rules.neon
 
 parameters:
     level: 8
     paths:
         - ../../src
+        - ../../tests
     symfony:
         container_xml_path: %currentWorkingDirectory%/var/cache/dev/srcDevDebugProjectContainer.xml

--- a/ibuildings/qa-pack/1.0/tools/phpunit.xml
+++ b/ibuildings/qa-pack/1.0/tools/phpunit.xml
@@ -1,18 +1,20 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
-<!-- https://phpunit.de/manual/current/en/appendixes.configuration.html -->
+<!-- https://phpunit.readthedocs.io/en/latest/configuration.html -->
 <phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:noNamespaceSchemaLocation="http://schema.phpunit.de/6.5/phpunit.xsd"
+         xsi:noNamespaceSchemaLocation="../../bin/.phpunit/phpunit.xsd"
          backupGlobals="false"
          colors="true"
-         bootstrap="../../config/bootstrap.php"
+         bootstrap="../../tests/bootstrap.php"
+         cacheResultFile="../../var/qa/phpunit.cache"
 >
     <php>
         <ini name="error_reporting" value="-1" />
         <server name="APP_ENV" value="test" force="true" />
         <server name="SHELL_VERBOSITY" value="-1" />
         <server name="SYMFONY_PHPUNIT_REMOVE" value="" />
-        <server name="SYMFONY_PHPUNIT_VERSION" value="6.5" />
+        <server name="SYMFONY_PHPUNIT_VERSION" value="7.5" />
+        <env name="SYMFONY_DEPRECATIONS_HELPER" value="verbose=0" />
     </php>
 
     <testsuites>
@@ -22,8 +24,8 @@
     </testsuites>
 
     <filter>
-        <whitelist>
-            <directory>../../src</directory>
+        <whitelist processUncoveredFilesFromWhitelist="true">
+            <directory suffix=".php">../../src</directory>
         </whitelist>
     </filter>
 

--- a/ibuildings/qa-pack/1.0/tools/security
+++ b/ibuildings/qa-pack/1.0/tools/security
@@ -2,4 +2,4 @@
 
 cd $(dirname $0)/../../
 
-./vendor/bin/security-checker security:check $1
+./vendor/bin/security-checker security:check


### PR DESCRIPTION
- By default include tests for various inspections as well
- Allow passing file/dir names to phpmd script
- Make sure to warm the symfony cache for phpstan
